### PR TITLE
Allow the GOPATH to be overwritten instead of fallback

### DIFF
--- a/lib/config/environment.js
+++ b/lib/config/environment.js
@@ -15,14 +15,14 @@ const getenvironment = (): {[string]: ?string} => {
 }
 
 const getgopath = (): string => {
-  // Preferred: The Environment
-  let g = process.env.GOPATH
+  // Preferred: Atom Config
+  let g = atom.config.get('go-plus.config.gopath')
   if (g && g.trim() !== '') {
-    return pathhelper.expand(process.env, g)
+    return g
   }
 
-  // Fallback: Atom Config
-  g = atom.config.get('go-plus.config.gopath')
+  // Fallback: The Environment
+  g = process.env.GOPATH
   if (g && g.trim() !== '') {
     return pathhelper.expand(process.env, g)
   }

--- a/package.json
+++ b/package.json
@@ -190,7 +190,7 @@
       "properties": {
         "gopath": {
           "title": "GOPATH",
-          "description": "(Not Recommended For Use) If you have issues setting your GOPATH in your environment, you can use this to establish a fallback value. See https://github.com/joefitzgerald/go-config/wiki/GOPATH for more information.",
+          "description": "Override the GOPATH",
           "type": "string",
           "default": "",
           "order": 1


### PR DESCRIPTION
Hello @iraAlor, 

Please review the following commits I made in branch 'eduardoramirez/override-go-path'.

7434f3fc22ebc6af2188d9e83fd28ae817e6ab60 (2018-08-16 12:52:26 -0700)
Allow the GOPATH to be overwritten instead of fallback

R=@iraAlor